### PR TITLE
TA 11 챌린지 조회 API 생성

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/TryAngle.main.iml" filepath="$PROJECT_DIR$/.idea/modules/TryAngle.main.iml" />
-    </modules>
-  </component>
-</project>

--- a/src/main/java/capstone/TryAngle/TryAngleApplication.java
+++ b/src/main/java/capstone/TryAngle/TryAngleApplication.java
@@ -2,12 +2,15 @@ package capstone.TryAngle;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@SpringBootApplication
+// 스프링 시큐리티 잠시 꺼둠
+@SpringBootApplication(exclude= SecurityAutoConfiguration.class)
 @EnableJpaAuditing
+@ComponentScan(basePackages = {"capstone.TryAngle", "capstone"})
 public class TryAngleApplication {
-
 	public static void main(String[] args) {
 		SpringApplication.run(TryAngleApplication.class, args);
 	}

--- a/src/main/java/capstone/TryAngle/common/ApiResponse.java
+++ b/src/main/java/capstone/TryAngle/common/ApiResponse.java
@@ -1,14 +1,39 @@
 package capstone.TryAngle.common;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import capstone.TryAngle.common.code.BaseCode;
+import capstone.TryAngle.common.status.SuccessStatus;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.*;
 
-@Data
-@NoArgsConstructor
+@Getter
 @AllArgsConstructor
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+@Builder
 public class ApiResponse<T> {
-    private boolean success;
-    private String message;
-    private T data;
+
+    @JsonProperty("isSuccess")
+    private final Boolean isSuccess;
+    private final String code;
+    private final String message;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T result;
+
+
+    // 성공한 경우 응답 생성
+
+    public static <T> ApiResponse<T> onSuccess(T result) {
+        return new ApiResponse<>(true, SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), result);
+    }
+
+    public static <T> ApiResponse<T> of(BaseCode code, T result) {
+        return new ApiResponse<>(true, code.getReasonHttpStatus().getCode(), code.getReasonHttpStatus().getMessage(), result);
+    }
+
+
+    // 실패한 경우 응답 생성
+    public static <T> ApiResponse<T> onFailure(String code, String message, T data) {
+        return new ApiResponse<>(false, code, message, data);
+    }
 }

--- a/src/main/java/capstone/TryAngle/common/GeneralException.java
+++ b/src/main/java/capstone/TryAngle/common/GeneralException.java
@@ -1,0 +1,20 @@
+package capstone.TryAngle.common;
+import capstone.TryAngle.common.code.BaseErrorCode;
+import capstone.TryAngle.common.code.ErrorReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GeneralException extends RuntimeException {
+
+    private BaseErrorCode code;
+
+    public ErrorReasonDTO getErrorReason() {
+        return this.code.getReason();
+    }
+
+    public ErrorReasonDTO getErrorReasonHttpStatus() {
+        return this.code.getReasonHttpStatus();
+    }
+}

--- a/src/main/java/capstone/TryAngle/common/code/BaseCode.java
+++ b/src/main/java/capstone/TryAngle/common/code/BaseCode.java
@@ -1,0 +1,9 @@
+package capstone.TryAngle.common.code;
+
+
+public interface BaseCode {
+
+    public ReasonDTO getReason();
+
+    public ReasonDTO getReasonHttpStatus();
+}

--- a/src/main/java/capstone/TryAngle/common/code/BaseErrorCode.java
+++ b/src/main/java/capstone/TryAngle/common/code/BaseErrorCode.java
@@ -1,0 +1,9 @@
+package capstone.TryAngle.common.code;
+
+
+public interface BaseErrorCode {
+
+    public ErrorReasonDTO getReason();
+
+    public ErrorReasonDTO getReasonHttpStatus();
+}

--- a/src/main/java/capstone/TryAngle/common/code/ErrorReasonDTO.java
+++ b/src/main/java/capstone/TryAngle/common/code/ErrorReasonDTO.java
@@ -1,0 +1,18 @@
+package capstone.TryAngle.common.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Builder
+@Getter
+@Data
+@AllArgsConstructor
+public class ErrorReasonDTO {
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+    private final boolean isSuccess;
+}

--- a/src/main/java/capstone/TryAngle/common/code/ReasonDTO.java
+++ b/src/main/java/capstone/TryAngle/common/code/ReasonDTO.java
@@ -1,0 +1,18 @@
+package capstone.TryAngle.common.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Builder
+@Getter
+@Data
+@AllArgsConstructor
+public class ReasonDTO {
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+    private final boolean isSuccess;
+}

--- a/src/main/java/capstone/TryAngle/common/status/ErrorStatus.java
+++ b/src/main/java/capstone/TryAngle/common/status/ErrorStatus.java
@@ -22,10 +22,11 @@ ErrorStatus implements BaseErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER4001", "사용자를 찾을수 없습니다."),
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "AUTH4001", "아이디 또는 비밀번호가 올바르지 않습니다"),
     DUPLICATE_NICKNAME(HttpStatus.UNAUTHORIZED, "USER4009", "이미 사용중인 닉네임입니다."),
-    NO_FOLLOW_INFO(HttpStatus.NOT_FOUND, "USER4008", "팔로우 정보가 존재하지 않습니다")
+    NO_FOLLOW_INFO(HttpStatus.NOT_FOUND, "USER4008", "팔로우 정보가 존재하지 않습니다"),
+
+    // 챌린지 관련 응답
+    CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHALLENGE$)$", "챌린지 정보가 존재하지 않습니다")
     ;
-
-
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;

--- a/src/main/java/capstone/TryAngle/common/status/ErrorStatus.java
+++ b/src/main/java/capstone/TryAngle/common/status/ErrorStatus.java
@@ -1,0 +1,55 @@
+package capstone.TryAngle.common.status;
+
+import capstone.TryAngle.common.code.BaseErrorCode;
+import capstone.TryAngle.common.code.ErrorReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum
+ErrorStatus implements BaseErrorCode {
+
+
+    // 가장 일반적인 응답
+    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON5000", "서버 에러, 관리자에게 문의 바랍니다."),
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON4000", "잘못된 요청입니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON4001", "인증이 필요합니다."),
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON4003", "금지된 요청입니다."),
+
+    // 사용자 관련 응답
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER4001", "사용자를 찾을수 없습니다."),
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "AUTH4001", "아이디 또는 비밀번호가 올바르지 않습니다"),
+    DUPLICATE_NICKNAME(HttpStatus.UNAUTHORIZED, "USER4009", "이미 사용중인 닉네임입니다."),
+    NO_FOLLOW_INFO(HttpStatus.NOT_FOUND, "USER4008", "팔로우 정보가 존재하지 않습니다")
+    ;
+
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+
+    @Override
+    public ErrorReasonDTO getReason() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDTO getReasonHttpStatus() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build()
+                ;
+
+
+    }
+}

--- a/src/main/java/capstone/TryAngle/common/status/SuccessStatus.java
+++ b/src/main/java/capstone/TryAngle/common/status/SuccessStatus.java
@@ -1,0 +1,38 @@
+package capstone.TryAngle.common.status;
+
+import capstone.TryAngle.common.code.BaseErrorCode;
+import capstone.TryAngle.common.code.ErrorReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessStatus implements BaseErrorCode {
+    // 가장 일반적인 응답
+    _OK(HttpStatus.OK, "COMMON200", "요청에 성공했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDTO getReason() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDTO getReasonHttpStatus() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build()
+                ;
+    }
+}

--- a/src/main/java/capstone/TryAngle/repository/ChallengeRepository.java
+++ b/src/main/java/capstone/TryAngle/repository/ChallengeRepository.java
@@ -1,4 +1,8 @@
 package capstone.TryAngle.repository;
 
-public class ChallengeRepository {
+import capstone.TryAngle.model.challenge.Challenge;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
+
 }

--- a/src/main/java/capstone/TryAngle/service/ChallengeService.java
+++ b/src/main/java/capstone/TryAngle/service/ChallengeService.java
@@ -9,4 +9,6 @@ public interface ChallengeService {
     List<ChallengeResponseDTO.getChallengeDTO> getChallenges();
 
     ChallengeResponseDTO.getChallengeDTO getChallengeById(Integer challengeId);
+
+    List<ChallengeResponseDTO.getChallengeDTO> getMyChallenges(String userid);
 }

--- a/src/main/java/capstone/TryAngle/service/ChallengeService.java
+++ b/src/main/java/capstone/TryAngle/service/ChallengeService.java
@@ -6,5 +6,7 @@ import java.util.List;
 
 
 public interface ChallengeService {
-    List<ChallengeResponseDTO.toChallengeDTO> getChallenges();
+    List<ChallengeResponseDTO.getChallengeDTO> getChallenges();
+
+    ChallengeResponseDTO.getChallengeDTO getChallengeById(Integer challengeId);
 }

--- a/src/main/java/capstone/TryAngle/service/ChallengeService.java
+++ b/src/main/java/capstone/TryAngle/service/ChallengeService.java
@@ -4,6 +4,7 @@ import capstone.TryAngle.web.dto.ChallengeResponseDTO;
 
 import java.util.List;
 
+
 public interface ChallengeService {
-    List<ChallengeResponseDTO.getChallengeDTO> getChallenges();
+    List<ChallengeResponseDTO.toChallengeDTO> getChallenges();
 }

--- a/src/main/java/capstone/TryAngle/service/ChallengeServiceImpl.java
+++ b/src/main/java/capstone/TryAngle/service/ChallengeServiceImpl.java
@@ -33,6 +33,11 @@ public class ChallengeServiceImpl implements ChallengeService {
                     .orElseThrow(() -> new GeneralException(ErrorStatus.CHALLENGE_NOT_FOUND));
             return ChallengeConverter.toChallengeDTO(challenge);
         }
+
+    @Override
+    public List<ChallengeResponseDTO.getChallengeDTO> getMyChallenges(String userid) {
+        return null;
     }
+}
 
 

--- a/src/main/java/capstone/TryAngle/service/ChallengeServiceImpl.java
+++ b/src/main/java/capstone/TryAngle/service/ChallengeServiceImpl.java
@@ -1,9 +1,11 @@
 package capstone.TryAngle.service;
 
+import capstone.TryAngle.common.GeneralException;
 import capstone.TryAngle.model.challenge.Challenge;
 import capstone.TryAngle.repository.ChallengeRepository;
 import capstone.TryAngle.web.converter.ChallengeConverter;
 import capstone.TryAngle.web.dto.ChallengeResponseDTO;
+import capstone.TryAngle.common.status.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,14 +19,20 @@ public class ChallengeServiceImpl implements ChallengeService {
     private final ChallengeRepository challengeRepository;
 
     @Override
-    public List<ChallengeResponseDTO.toChallengeDTO> getChallenges() {
+    public List<ChallengeResponseDTO.getChallengeDTO> getChallenges() {
         List<Challenge> challenges;
         challenges = challengeRepository.findAll();
         return ChallengeConverter.toChallengeListDTO(challenges);
 
     }
 
+    @Override
+    public ChallengeResponseDTO.getChallengeDTO getChallengeById(Integer challengeId) {
+            Challenge challenge = challengeRepository.findById(Long.valueOf(challengeId))
+                    // findById(Long) 으로만 받는거 같은데 Integer -> Long 으로 바꾸는게 어떨까용...?
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.CHALLENGE_NOT_FOUND));
+            return ChallengeConverter.toChallengeDTO(challenge);
+        }
+    }
 
 
-
-}

--- a/src/main/java/capstone/TryAngle/service/ChallengeServiceImpl.java
+++ b/src/main/java/capstone/TryAngle/service/ChallengeServiceImpl.java
@@ -1,16 +1,30 @@
 package capstone.TryAngle.service;
 
+import capstone.TryAngle.model.challenge.Challenge;
 import capstone.TryAngle.repository.ChallengeRepository;
+import capstone.TryAngle.web.converter.ChallengeConverter;
 import capstone.TryAngle.web.dto.ChallengeResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+@Service
+@RequiredArgsConstructor
+@Transactional
 public class ChallengeServiceImpl implements ChallengeService {
+    private final ChallengeRepository challengeRepository;
 
     @Override
-    public List<ChallengeResponseDTO.getChallengeDTO> getChallenges() {
-        return null;
+    public List<ChallengeResponseDTO.toChallengeDTO> getChallenges() {
+        List<Challenge> challenges;
+        challenges = challengeRepository.findAll();
+        return ChallengeConverter.toChallengeListDTO(challenges);
+
     }
+
+
 
 
 }

--- a/src/main/java/capstone/TryAngle/web/controller/ChallengeController.java
+++ b/src/main/java/capstone/TryAngle/web/controller/ChallengeController.java
@@ -3,17 +3,20 @@ package capstone.TryAngle.web.controller;
 import capstone.TryAngle.common.ApiResponse;
 import capstone.TryAngle.service.ChallengeService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/challenge")
 public class ChallengeController {
-
     private final ChallengeService challengeService;
+
+    @GetMapping
+    public ApiResponse<?> getChallenges(){
+        return ApiResponse.onSuccess( challengeService.getChallenges());
+    }
+
+    @
 
 
 }

--- a/src/main/java/capstone/TryAngle/web/controller/ChallengeController.java
+++ b/src/main/java/capstone/TryAngle/web/controller/ChallengeController.java
@@ -23,6 +23,12 @@ public class ChallengeController {
 
     }
 
+    @GetMapping("my")
+    public ApiResponse<?> getMyChallenges( @RequestHeader(value = "Authorization", required = true) String authorizationHeader){
+        String userid = authorizationHeader.replace("Bearer ", "");
+        return ApiResponse.onSuccess(challengeService.getMyChallenges(userid));
+    }
+
 
 
 

--- a/src/main/java/capstone/TryAngle/web/controller/ChallengeController.java
+++ b/src/main/java/capstone/TryAngle/web/controller/ChallengeController.java
@@ -2,6 +2,7 @@ package capstone.TryAngle.web.controller;
 
 import capstone.TryAngle.common.ApiResponse;
 import capstone.TryAngle.service.ChallengeService;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -16,7 +17,13 @@ public class ChallengeController {
         return ApiResponse.onSuccess( challengeService.getChallenges());
     }
 
-    @
+    @GetMapping("/{challengeId}")
+    public ApiResponse<?> getChallengeById( @PathVariable Integer challengeId){
+        return  ApiResponse.onSuccess(challengeService.getChallengeById(challengeId));
+
+    }
+
+
 
 
 }

--- a/src/main/java/capstone/TryAngle/web/converter/ChallengeConverter.java
+++ b/src/main/java/capstone/TryAngle/web/converter/ChallengeConverter.java
@@ -7,9 +7,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class ChallengeConverter {
-    public static List<ChallengeResponseDTO.toChallengeDTO> toChallengeListDTO(List<Challenge> challenges) {
+    public static List<ChallengeResponseDTO.getChallengeDTO> toChallengeListDTO(List<Challenge> challenges) {
         return challenges.stream()
-                .map(challenge -> new ChallengeResponseDTO.toChallengeDTO(
+                .map(challenge -> new ChallengeResponseDTO.getChallengeDTO(
                         challenge.getChallengeId(),
                         challenge.getChallengeName(),
                         challenge.getChallengeThumbnail(),
@@ -28,5 +28,30 @@ public class ChallengeConverter {
                         challenge.getLeader().getNickname()
                 ))
                 .collect(Collectors.toList());
+    };
+
+
+
+    public static ChallengeResponseDTO.getChallengeDTO toChallengeDTO(Challenge challenge) {
+        return new ChallengeResponseDTO.getChallengeDTO(
+                        challenge.getChallengeId(),
+                        challenge.getChallengeName(),
+                        challenge.getChallengeThumbnail(),
+                        challenge.getChallengeShortIntro(),
+                        challenge.getCategory(),
+                        challenge.getChallengePublic(),
+                        challenge.getStartDate(),
+                        challenge.getEndDate(),
+                        challenge.getAuthTimeStart(),
+                        challenge.getAuthTimeEnd(),
+                        challenge.getMaxPeople(),
+                        challenge.getNowPeople(),
+                        challenge.getMinDeposit(),
+                        challenge.getReturnType(),
+                        challenge.getAuthFrequency(),
+                        challenge.getLeader().getNickname()
+        );
+
     }
+
 }

--- a/src/main/java/capstone/TryAngle/web/converter/ChallengeConverter.java
+++ b/src/main/java/capstone/TryAngle/web/converter/ChallengeConverter.java
@@ -1,0 +1,32 @@
+package capstone.TryAngle.web.converter;
+
+import capstone.TryAngle.model.challenge.Challenge;
+import capstone.TryAngle.web.dto.ChallengeResponseDTO;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ChallengeConverter {
+    public static List<ChallengeResponseDTO.toChallengeDTO> toChallengeListDTO(List<Challenge> challenges) {
+        return challenges.stream()
+                .map(challenge -> new ChallengeResponseDTO.toChallengeDTO(
+                        challenge.getChallengeId(),
+                        challenge.getChallengeName(),
+                        challenge.getChallengeThumbnail(),
+                        challenge.getChallengeShortIntro(),
+                        challenge.getCategory(),
+                        challenge.getChallengePublic(),
+                        challenge.getStartDate(),
+                        challenge.getEndDate(),
+                        challenge.getAuthTimeStart(),
+                        challenge.getAuthTimeEnd(),
+                        challenge.getMaxPeople(),
+                        challenge.getNowPeople(),
+                        challenge.getMinDeposit(),
+                        challenge.getReturnType(),
+                        challenge.getAuthFrequency(),
+                        challenge.getLeader().getNickname()
+                ))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/capstone/TryAngle/web/dto/ChallengeResponseDTO.java
+++ b/src/main/java/capstone/TryAngle/web/dto/ChallengeResponseDTO.java
@@ -1,6 +1,39 @@
 package capstone.TryAngle.web.dto;
 
+import capstone.TryAngle.model.challenge.Category;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
 public class ChallengeResponseDTO {
-    public class getChallengeDTO {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class toChallengeDTO {
+
+        private  Integer challenge_id;
+        private String challenge_name;
+        private String challenge_thumbnail;
+        private String challenge_shortIntro;
+        private Category category;
+        private boolean challenge_public;
+        private LocalDate start_date;
+        private LocalDate end_date;
+        private LocalTime auth_time_start;
+        private LocalTime auth_time_end;
+        private Integer max_people;
+        private Integer now_people;
+        private Integer min_deposit;
+        private boolean return_type;
+        private String auth_frequency;
+        private String leader_nickname;
+
     }
+
 }

--- a/src/main/java/capstone/TryAngle/web/dto/ChallengeResponseDTO.java
+++ b/src/main/java/capstone/TryAngle/web/dto/ChallengeResponseDTO.java
@@ -15,9 +15,9 @@ public class ChallengeResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
-    public static class toChallengeDTO {
+    public static class getChallengeDTO {
 
-        private  Integer challenge_id;
+        private Integer challenge_id;
         private String challenge_name;
         private String challenge_thumbnail;
         private String challenge_shortIntro;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,13 @@
 spring.application.name=TryAngle
+server.port=8080
+
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.url=jdbc:mysql://localhost:3306/triangle
+spring.datasource.username=root
+spring.datasource.password=mysql1234
+
+
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect


### PR DESCRIPTION
<img width="945" alt="스크린샷 2025-04-30 오후 2 17 14" src="https://github.com/user-attachments/assets/c85bf759-9df1-44c5-9756-de643f3dbbb1" />

- [x] 전체 챌린지 조회
- [x] 개별 챌린지 조회
- [ ] 나의 챌린지 조회 (미완성) 

구현했습니다. 미완성이지만 일단 공통 모듈 공유를 위해 먼저 푸시합니다.

+) Common 폴더에 공통 응답 생성 관련 파일 생성했습니다.
1. 에러/성공 상태 코드 추가시 common > status > ErrorStatus, SuccessStatus에 추가하시면 됩니다.
2. controller와 dto, converter는 web 폴더에 있습니다. 응답 or 요청값을 dto로 받아와서 필요한 리턴값으로 변환할때 converter를 거칩니다.