### PR TITLE
GlobalException 처리 & Spring Security 주석 추가

### DIFF
--- a/src/main/java/capstone/TryAngle/common/ApiResponse.java
+++ b/src/main/java/capstone/TryAngle/common/ApiResponse.java
@@ -33,7 +33,7 @@ public class ApiResponse<T> {
 
 
     // 실패한 경우 응답 생성
-    public static <T> ApiResponse<T> onFailure(String code, String message, T data) {
-        return new ApiResponse<>(false, code, message, data);
+    public static <T> ApiResponse<T> onFailure(String code, String message, T result) {
+        return new ApiResponse<>(false, code, message, result);
     }
 }

--- a/src/main/java/capstone/TryAngle/common/GlobalExceptionHandler.java
+++ b/src/main/java/capstone/TryAngle/common/GlobalExceptionHandler.java
@@ -9,10 +9,15 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(GeneralException.class)
-    public ResponseEntity<ErrorReasonDTO> handleGeneralException(GeneralException ex) {
+    public ResponseEntity<ApiResponse<Object>> handleGeneralException(GeneralException ex) {
         ErrorReasonDTO errorResponse = ex.getErrorReasonHttpStatus();
+        ApiResponse<Object> response = ApiResponse.onFailure(
+                errorResponse.getCode(),
+                errorResponse.getMessage(),
+                errorResponse.getHttpStatus().name()
+        );
         return ResponseEntity
                 .status(errorResponse.getHttpStatus())
-                .body(errorResponse);
+                .body(response);
     }
 }

--- a/src/main/java/capstone/TryAngle/common/status/SuccessStatus.java
+++ b/src/main/java/capstone/TryAngle/common/status/SuccessStatus.java
@@ -1,14 +1,14 @@
 package capstone.TryAngle.common.status;
 
-import capstone.TryAngle.common.code.BaseErrorCode;
-import capstone.TryAngle.common.code.ErrorReasonDTO;
+import capstone.TryAngle.common.code.BaseCode;
+import capstone.TryAngle.common.code.ReasonDTO;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
-public enum SuccessStatus implements BaseErrorCode {
+public enum SuccessStatus implements BaseCode {
     // 가장 일반적인 응답
     _OK(HttpStatus.OK, "COMMON200", "요청에 성공했습니다."),
 
@@ -23,8 +23,8 @@ public enum SuccessStatus implements BaseErrorCode {
     private final String message;
 
     @Override
-    public ErrorReasonDTO getReason() {
-        return ErrorReasonDTO.builder()
+    public ReasonDTO getReason() {
+        return ReasonDTO.builder()
                 .message(message)
                 .code(code)
                 .isSuccess(true)
@@ -32,8 +32,8 @@ public enum SuccessStatus implements BaseErrorCode {
     }
 
     @Override
-    public ErrorReasonDTO getReasonHttpStatus() {
-        return ErrorReasonDTO.builder()
+    public ReasonDTO getReasonHttpStatus() {
+        return ReasonDTO.builder()
                 .message(message)
                 .code(code)
                 .isSuccess(true)

--- a/src/main/java/capstone/TryAngle/config/JwtAccessDeniedHandler.java
+++ b/src/main/java/capstone/TryAngle/config/JwtAccessDeniedHandler.java
@@ -12,7 +12,7 @@ import java.io.IOException;
 @Component
 public class JwtAccessDeniedHandler implements AccessDeniedHandler {
     @Override
-    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException {
         // 필요한 권한 없이 접근하려 할 때 403
         response.sendError(HttpServletResponse.SC_FORBIDDEN);
     }

--- a/src/main/java/capstone/TryAngle/config/JwtFilter.java
+++ b/src/main/java/capstone/TryAngle/config/JwtFilter.java
@@ -46,6 +46,7 @@ public class JwtFilter extends GenericFilterBean {
 
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
             return bearerToken.substring(7);
+            // "Bearer " 이후 실제 토큰만 추출
         }
 
         return null;

--- a/src/main/java/capstone/TryAngle/config/SecurityConfig.java
+++ b/src/main/java/capstone/TryAngle/config/SecurityConfig.java
@@ -16,28 +16,35 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    private final TokenProvider tokenProvider;
-    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
-    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    private final TokenProvider tokenProvider; // JWT 생성 및 검증
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint; // 인증 실패 시 처리
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler; // 인가 실패 시 처리
 
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 
+    // Spring Security 필터 체인 설정
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
         httpSecurity
+                // CSRF 보호 기능 비활성화
                 .csrf(csrf -> csrf.disable())
+                // 세션 사용하지 않으므로 stateless
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                // 예외 처리 핸들러
                 .exceptionHandling(ex -> ex
                         .authenticationEntryPoint(jwtAuthenticationEntryPoint)
                         .accessDeniedHandler(jwtAccessDeniedHandler))
+                // HttpServletRequest를 사용하는 요청들에 대해 접근제한 설정
                 .authorizeHttpRequests(auth -> auth
-//                        .requestMatchers("/user/login", "/user/signup", "/user/checkEmail", "/user/checkNickname").permitAll()
-                        .requestMatchers("/user/*", "/challenge/*").permitAll() // 임시적으로 모두 허용
-                        .anyRequest().authenticated())
+                        // 인증 없이 가능한 경우
+                        .requestMatchers("/user/login", "/user/signup", "/user/checkEmail").permitAll()
+//                        .requestMatchers("/user/*", "/challenge/*").permitAll() // 임시적으로 모두 허용
+                        .anyRequest().authenticated()) // 그 외에는 인증 없이 접근 불가
+                // JWT 인증 필터를 UsernamePasswordAuthenticationFilter 이전에 등록
                 .addFilterBefore(new JwtFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class);
 
         return httpSecurity.build();

--- a/src/main/java/capstone/TryAngle/config/TokenProvider.java
+++ b/src/main/java/capstone/TryAngle/config/TokenProvider.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 @Component
 public class TokenProvider {
     private final Key key;
-    private final long tokenValidityInMilliseconds;
+    private final long tokenValidityInMilliseconds; // 토큰 유효 시간
     private final Logger logger = LoggerFactory.getLogger(TokenProvider.class);
 
     public TokenProvider(
@@ -38,7 +38,7 @@ public class TokenProvider {
                 .map(GrantedAuthority::getAuthority)
                 .collect(Collectors.joining(","));
 
-        // 토큰의 expire 시간을 설정
+        // 현재 시간 기준으로 토큰의 expire 시간을 설정
         long now = System.currentTimeMillis();
         Date validity = new Date(now + this.tokenValidityInMilliseconds);
 


### PR DESCRIPTION
Success와 Failure의 응답이 다르게 나와서 보니
GlobalExceptionHandler에서 ApiResponse를 사용하지 않고 있었습니다.

따라서 GlobalExcpetionHandler에서 ApiResponse를 담아
Sucess와 동일한 형식으로 Exception 처리할 수 있도록 했습니다!

또한 Spring Security 설정 관련 이해하기 쉽도록 주석 추가했습니다.

- 성공시
![image](https://github.com/user-attachments/assets/8125f9bb-bcf3-4033-91d7-79017c057624)

- 실패시 (409 Error)
![image](https://github.com/user-attachments/assets/4cdd6342-dae8-4edd-b6de-de2c0df7c212)

- 실패시 (400 Errror)
![image](https://github.com/user-attachments/assets/27de7809-5011-4e5a-ab44-6965c2b760c2)
