### PR TITLE
Ta 14 마이페이지 조회 구현

### DIFF
--- a/src/main/java/capstone/TryAngle/common/ApiResponse.java
+++ b/src/main/java/capstone/TryAngle/common/ApiResponse.java
@@ -33,7 +33,7 @@ public class ApiResponse<T> {
 
 
     // 실패한 경우 응답 생성
-    public static <T> ApiResponse<T> onFailure(String code, String message, T data) {
-        return new ApiResponse<>(false, code, message, data);
+    public static <T> ApiResponse<T> onFailure(String code, String message, T result) {
+        return new ApiResponse<>(false, code, message, result);
     }
 }

--- a/src/main/java/capstone/TryAngle/common/GlobalExceptionHandler.java
+++ b/src/main/java/capstone/TryAngle/common/GlobalExceptionHandler.java
@@ -9,10 +9,15 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(GeneralException.class)
-    public ResponseEntity<ErrorReasonDTO> handleGeneralException(GeneralException ex) {
+    public ResponseEntity<ApiResponse<Object>> handleGeneralException(GeneralException ex) {
         ErrorReasonDTO errorResponse = ex.getErrorReasonHttpStatus();
+        ApiResponse<Object> response = ApiResponse.onFailure(
+                errorResponse.getCode(),
+                errorResponse.getMessage(),
+                errorResponse.getHttpStatus().name()
+        );
         return ResponseEntity
                 .status(errorResponse.getHttpStatus())
-                .body(errorResponse);
+                .body(response);
     }
 }

--- a/src/main/java/capstone/TryAngle/common/status/SuccessStatus.java
+++ b/src/main/java/capstone/TryAngle/common/status/SuccessStatus.java
@@ -1,14 +1,14 @@
 package capstone.TryAngle.common.status;
 
-import capstone.TryAngle.common.code.BaseErrorCode;
-import capstone.TryAngle.common.code.ErrorReasonDTO;
+import capstone.TryAngle.common.code.BaseCode;
+import capstone.TryAngle.common.code.ReasonDTO;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
-public enum SuccessStatus implements BaseErrorCode {
+public enum SuccessStatus implements BaseCode {
     // 가장 일반적인 응답
     _OK(HttpStatus.OK, "COMMON200", "요청에 성공했습니다."),
 
@@ -23,8 +23,8 @@ public enum SuccessStatus implements BaseErrorCode {
     private final String message;
 
     @Override
-    public ErrorReasonDTO getReason() {
-        return ErrorReasonDTO.builder()
+    public ReasonDTO getReason() {
+        return ReasonDTO.builder()
                 .message(message)
                 .code(code)
                 .isSuccess(true)
@@ -32,8 +32,8 @@ public enum SuccessStatus implements BaseErrorCode {
     }
 
     @Override
-    public ErrorReasonDTO getReasonHttpStatus() {
-        return ErrorReasonDTO.builder()
+    public ReasonDTO getReasonHttpStatus() {
+        return ReasonDTO.builder()
                 .message(message)
                 .code(code)
                 .isSuccess(true)

--- a/src/main/java/capstone/TryAngle/config/JwtAccessDeniedHandler.java
+++ b/src/main/java/capstone/TryAngle/config/JwtAccessDeniedHandler.java
@@ -12,7 +12,7 @@ import java.io.IOException;
 @Component
 public class JwtAccessDeniedHandler implements AccessDeniedHandler {
     @Override
-    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException {
         // 필요한 권한 없이 접근하려 할 때 403
         response.sendError(HttpServletResponse.SC_FORBIDDEN);
     }

--- a/src/main/java/capstone/TryAngle/config/JwtAccessDeniedHandler.java
+++ b/src/main/java/capstone/TryAngle/config/JwtAccessDeniedHandler.java
@@ -1,8 +1,11 @@
 package capstone.TryAngle.config;
 
+import capstone.TryAngle.common.ApiResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
@@ -10,10 +13,24 @@ import org.springframework.stereotype.Component;
 import java.io.IOException;
 
 @Component
+@RequiredArgsConstructor
 public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+    private final ObjectMapper objectMapper;
+
     @Override
-    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException {
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
         // 필요한 권한 없이 접근하려 할 때 403
-        response.sendError(HttpServletResponse.SC_FORBIDDEN);
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        ApiResponse<?> body = ApiResponse.onFailure(
+                "AUTH4003",
+                "접근 권한이 없습니다.",
+                null
+        );
+        response.getWriter().write(objectMapper.writeValueAsString(body));
     }
 }

--- a/src/main/java/capstone/TryAngle/config/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/capstone/TryAngle/config/JwtAuthenticationEntryPoint.java
@@ -1,7 +1,10 @@
 package capstone.TryAngle.config;
 
+import capstone.TryAngle.common.ApiResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
@@ -9,12 +12,24 @@ import org.springframework.stereotype.Component;
 import java.io.IOException;
 
 @Component
+@RequiredArgsConstructor
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final ObjectMapper objectMapper;
+
     @Override
     public void commence(HttpServletRequest request,
                          HttpServletResponse response,
                          AuthenticationException authException) throws IOException {
         // 유효한 자격증명을 제공하지 않고 접근하려 할때 401
-        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        ApiResponse<?> body = ApiResponse.onFailure(
+                "AUTH4001",
+                "토큰 누락 또는 유효하지 않은 토큰입니다.",
+                null
+        );
+        response.getWriter().write(objectMapper.writeValueAsString(body));
     }
 }

--- a/src/main/java/capstone/TryAngle/config/JwtFilter.java
+++ b/src/main/java/capstone/TryAngle/config/JwtFilter.java
@@ -46,6 +46,7 @@ public class JwtFilter extends GenericFilterBean {
 
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
             return bearerToken.substring(7);
+            // "Bearer " 이후 실제 토큰만 추출
         }
 
         return null;

--- a/src/main/java/capstone/TryAngle/config/SecurityConfig.java
+++ b/src/main/java/capstone/TryAngle/config/SecurityConfig.java
@@ -16,28 +16,35 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    private final TokenProvider tokenProvider;
-    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
-    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    private final TokenProvider tokenProvider; // JWT 생성 및 검증
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint; // 인증 실패 시 처리
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler; // 인가 실패 시 처리
 
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 
+    // Spring Security 필터 체인 설정
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
         httpSecurity
+                // CSRF 보호 기능 비활성화
                 .csrf(csrf -> csrf.disable())
+                // 세션 사용하지 않으므로 stateless
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                // 예외 처리 핸들러
                 .exceptionHandling(ex -> ex
                         .authenticationEntryPoint(jwtAuthenticationEntryPoint)
                         .accessDeniedHandler(jwtAccessDeniedHandler))
+                // HttpServletRequest를 사용하는 요청들에 대해 접근제한 설정
                 .authorizeHttpRequests(auth -> auth
-//                        .requestMatchers("/user/login", "/user/signup", "/user/checkEmail", "/user/checkNickname").permitAll()
-                        .requestMatchers("/user/*", "/challenge/*").permitAll() // 임시적으로 모두 허용
-                        .anyRequest().authenticated())
+                        // 인증 없이 가능한 경우
+                        .requestMatchers("/user/login", "/user/signup", "/user/checkEmail").permitAll()
+//                        .requestMatchers("/user/*", "/challenge/*").permitAll() // 임시적으로 모두 허용
+                        .anyRequest().authenticated()) // 그 외에는 인증 없이 접근 불가
+                // JWT 인증 필터를 UsernamePasswordAuthenticationFilter 이전에 등록
                 .addFilterBefore(new JwtFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class);
 
         return httpSecurity.build();

--- a/src/main/java/capstone/TryAngle/config/TokenProvider.java
+++ b/src/main/java/capstone/TryAngle/config/TokenProvider.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 @Component
 public class TokenProvider {
     private final Key key;
-    private final long tokenValidityInMilliseconds;
+    private final long tokenValidityInMilliseconds; // 토큰 유효 시간
     private final Logger logger = LoggerFactory.getLogger(TokenProvider.class);
 
     public TokenProvider(
@@ -38,7 +38,7 @@ public class TokenProvider {
                 .map(GrantedAuthority::getAuthority)
                 .collect(Collectors.joining(","));
 
-        // 토큰의 expire 시간을 설정
+        // 현재 시간 기준으로 토큰의 expire 시간을 설정
         long now = System.currentTimeMillis();
         Date validity = new Date(now + this.tokenValidityInMilliseconds);
 

--- a/src/main/java/capstone/TryAngle/model/user/User.java
+++ b/src/main/java/capstone/TryAngle/model/user/User.java
@@ -43,6 +43,10 @@ public class User {
     @Column(name = "profile_image", length = 300)
     private String profileImage;
 
+    @Column(name = "challenge_money")
+    @Builder.Default
+    private Integer challengeMoney = 0;
+
     @Column(name = "return_money")
     @Builder.Default
     private Integer returnMoney = 0;
@@ -50,15 +54,30 @@ public class User {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<UserBadge> userBadges = new ArrayList<>();
 
+    @Column(length = 50)
+    private String badgeDescription; // 뱃지 기반 소개
+
+    // 내가 팔로우한 사람들
+    @OneToMany(mappedBy = "follower", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Follow> followees = new ArrayList<>();
+
+    // 나를 팔로우한 사람들
+    @OneToMany(mappedBy = "followee", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Follow> followers = new ArrayList<>();
+
     public User(String email, String password, String name, String phone,
-                String description, String nickname, String profileImage, Integer returnMoney) {
+                String description, String badgeDescription, String nickname,
+                String profileImage, Integer challengeMoney, Integer returnMoney) {
         this.email = email;
         this.password = password;
         this.name = name;
         this.phone = phone;
         this.description = description;
+        this.badgeDescription = badgeDescription;
         this.nickname = nickname;
         this.profileImage = profileImage;
+        this.challengeMoney = challengeMoney;
         this.returnMoney = returnMoney;
     }
+
 }

--- a/src/main/java/capstone/TryAngle/repository/FollowRepository.java
+++ b/src/main/java/capstone/TryAngle/repository/FollowRepository.java
@@ -1,0 +1,11 @@
+package capstone.TryAngle.repository;
+
+import capstone.TryAngle.model.user.Follow;
+import capstone.TryAngle.model.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+    int countByFollowee(User user);
+
+    int countByFollower(User user);
+}

--- a/src/main/java/capstone/TryAngle/service/UserService.java
+++ b/src/main/java/capstone/TryAngle/service/UserService.java
@@ -1,0 +1,7 @@
+package capstone.TryAngle.service;
+
+import capstone.TryAngle.web.dto.UserResponseDTO;
+
+public interface UserService {
+    UserResponseDTO.MypageDTO getMypageByEmail(String email);
+}

--- a/src/main/java/capstone/TryAngle/service/UserServiceImpl.java
+++ b/src/main/java/capstone/TryAngle/service/UserServiceImpl.java
@@ -1,0 +1,32 @@
+package capstone.TryAngle.service;
+
+import capstone.TryAngle.common.GeneralException;
+import capstone.TryAngle.common.status.ErrorStatus;
+import capstone.TryAngle.model.user.User;
+import capstone.TryAngle.repository.FollowRepository;
+import capstone.TryAngle.repository.UserRepository;
+import capstone.TryAngle.web.converter.UserConverter;
+import capstone.TryAngle.web.dto.UserResponseDTO;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserServiceImpl implements UserService {
+    private final UserRepository userRepository;
+    private final FollowRepository followRepository;
+
+    @Override
+    public UserResponseDTO.MypageDTO getMypageByEmail(String email) {
+        // userId로 유저 정보 조회
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(()->new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        int followerCnt = followRepository.countByFollowee(user); // 나를 팔로우하는 사람들
+        int followeeCnt = followRepository.countByFollower(user); // 내가 팔로우하는 사람들
+
+        return UserConverter.toMyPage(user, followerCnt, followeeCnt);
+    }
+}

--- a/src/main/java/capstone/TryAngle/web/controller/MypageController.java
+++ b/src/main/java/capstone/TryAngle/web/controller/MypageController.java
@@ -1,0 +1,25 @@
+package capstone.TryAngle.web.controller;
+
+import capstone.TryAngle.common.ApiResponse;
+import capstone.TryAngle.common.status.SuccessStatus;
+import capstone.TryAngle.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/user")
+public class MypageController {
+    private final UserService userService;
+
+    @GetMapping("/mypage")
+    public ApiResponse<?> getMypage(@AuthenticationPrincipal User user) {
+        String email = user.getUsername();
+        return ApiResponse.onSuccess(SuccessStatus._OK, userService.getMypageByEmail(email));
+    }
+
+}

--- a/src/main/java/capstone/TryAngle/web/converter/UserConverter.java
+++ b/src/main/java/capstone/TryAngle/web/converter/UserConverter.java
@@ -2,10 +2,11 @@ package capstone.TryAngle.web.converter;
 
 import capstone.TryAngle.model.user.User;
 import capstone.TryAngle.web.dto.UserRequestDTO;
+import capstone.TryAngle.web.dto.UserResponseDTO;
 
 public class UserConverter {
 
-    public static User toUser(UserRequestDTO.SignupRequestDTO dto,  String encodedPassword) {
+    public static User toUser(UserRequestDTO.SignupRequestDTO dto, String encodedPassword) {
         return User.builder()
                 .email(dto.getEmail())
                 .name(dto.getName())
@@ -15,5 +16,22 @@ public class UserConverter {
                 .description(dto.getDescription())
                 .profileImage(dto.getProfileImage())
                 .build();
+    }
+
+    public static UserResponseDTO.MypageDTO toMyPage(User user, int followerCnt, int followeeCnt) {
+        return new UserResponseDTO.MypageDTO(
+                user.getUserId(),
+                user.getEmail(),
+                user.getName(),
+                user.getPhone(),
+                user.getDescription(),
+                user.getBadgeDescription(),
+                user.getNickname(),
+                user.getProfileImage(),
+                user.getChallengeMoney(),
+                user.getReturnMoney(),
+                followerCnt,
+                followeeCnt
+        );
     }
 }

--- a/src/main/java/capstone/TryAngle/web/dto/UserResponseDTO.java
+++ b/src/main/java/capstone/TryAngle/web/dto/UserResponseDTO.java
@@ -10,4 +10,21 @@ public class UserResponseDTO {
     public static class LoginResponseDTO {
         private String token;
     }
+
+    @Getter
+    @AllArgsConstructor
+    public static class MypageDTO {
+        private Integer userId;
+        private String email;
+        private String name;
+        private String phone;
+        private String description;
+        private String badgeDescription;
+        private String nickname;
+        private String profileImage;
+        private Integer challengeMoney;
+        private Integer returnMoney;
+        private Integer followers;
+        private Integer followees;
+    }
 }


### PR DESCRIPTION
**마이페이지 조회 기능** 구현했습니다.
ERD랑 엔티티에 challengeMoney, badgeDescription이 누락되어 있어서 추가해서 구현했고,
postman으로 테스팅 및 example 업데이트 완료했습니둥

마이페이지 세부 기능들을 요 브랜치에서 추가적으로 구현할 예정이지만,
토큰 누락 및 유효하지 않은 토큰 처리 GlobalException을
통일해서 사용해야 할 것 같아서 먼저 PR 쏩니다!

- 마이페이지 조회 성공 응답
<img width="959" alt="image" src="https://github.com/user-attachments/assets/290ba77e-a8d5-444d-90cb-265b32fbb9cf" />

- 토큰 누락 또는 유효하지 않은 토큰 응답
<img width="966" alt="image" src="https://github.com/user-attachments/assets/8e676ab2-d13d-4cc3-bd98-27e7c542ffb7" />
