### PR TITLE
feat: 현재 닉네임 일치시 유저 수정

### DIFF
--- a/src/main/java/capstone/TryAngle/service/UserServiceImpl.java
+++ b/src/main/java/capstone/TryAngle/service/UserServiceImpl.java
@@ -51,7 +51,9 @@ public class UserServiceImpl implements UserService {
     public void modifyUserInfo(String email, UserRequestDTO.ModifyUserRequestDTO userDto) {
         User user = findUserByEmail(email);
 
-        authService.validateNickname(userDto.getNickname());
+        if (!user.getNickname().equals(userDto.getNickname())) {
+            authService.validateNickname(userDto.getNickname());
+        }
         user.updateUser(userDto.getNickname(), userDto.getProfileImage());
     }
 


### PR DESCRIPTION
프론트 측에서 요청해주신 것처럼
현재 닉네임과 일치할 시에는 닉네임 중복 확인하지 않도록 수정했습니다.