### PR TITLE
feat: 랭킹 조회 기능 구현

### DIFF
--- a/src/main/java/capstone/TryAngle/config/security/SecurityConfig.java
+++ b/src/main/java/capstone/TryAngle/config/security/SecurityConfig.java
@@ -54,7 +54,7 @@ public class SecurityConfig {
 //                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         // 인증 없이 가능한 경우
                         .requestMatchers("/user/login", "/user/signup", "/user/checkEmail", "/user/checkNickname",
-                                "/user/findId", "user/resetPassword").permitAll()
+                                "/user/findId", "user/resetPassword", "/ranking").permitAll()
                         .requestMatchers(HttpMethod.GET, "/challenge/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/uploads/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/challenge").authenticated()

--- a/src/main/java/capstone/TryAngle/repository/ParticipationRepository.java
+++ b/src/main/java/capstone/TryAngle/repository/ParticipationRepository.java
@@ -18,4 +18,10 @@ public interface ParticipationRepository extends JpaRepository<Participation, In
     List<Participation> findAllByChallengeChallengeId(Integer challengeId);
 
     int countByChallengeChallengeId(Integer challengeId);
+
+    @Query("SELECT DISTINCT p FROM Participation p " +
+            "JOIN FETCH p.challenge c " +
+            "LEFT JOIN FETCH p.authList a")
+    List<Participation> findAllWithChallengeAndAuth();
+
 }

--- a/src/main/java/capstone/TryAngle/service/RankingService.java
+++ b/src/main/java/capstone/TryAngle/service/RankingService.java
@@ -1,0 +1,10 @@
+package capstone.TryAngle.service;
+
+import capstone.TryAngle.web.dto.RankingResponseDTO;
+
+import java.util.List;
+
+public interface RankingService {
+    List<RankingResponseDTO> getAllRanking();
+    List<RankingResponseDTO> getFollowingRanking(String email);
+}

--- a/src/main/java/capstone/TryAngle/service/RankingServiceImpl.java
+++ b/src/main/java/capstone/TryAngle/service/RankingServiceImpl.java
@@ -1,0 +1,112 @@
+package capstone.TryAngle.service;
+
+import capstone.TryAngle.common.GeneralException;
+import capstone.TryAngle.common.status.ErrorStatus;
+import capstone.TryAngle.model.challenge.Auth;
+import capstone.TryAngle.model.challenge.Challenge;
+import capstone.TryAngle.model.challenge.Participation;
+import capstone.TryAngle.model.user.User;
+import capstone.TryAngle.repository.ParticipationRepository;
+import capstone.TryAngle.repository.UserRepository;
+import capstone.TryAngle.repository.FollowRepository;
+import capstone.TryAngle.web.dto.RankingResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class RankingServiceImpl implements RankingService {
+
+    private final ParticipationRepository participationRepository;
+    private final UserRepository userRepository;
+    private final FollowRepository followRepository;
+
+    public List<RankingResponseDTO> getAllRanking() {
+        List<Participation> participations = participationRepository.findAllWithChallengeAndAuth();
+
+        Map<User, List<Participation>> userMap = participations.stream()
+                .collect(Collectors.groupingBy(Participation::getUser));
+
+        List<RankingResponseDTO> result = new ArrayList<>();
+
+        for (Map.Entry<User, List<Participation>> entry : userMap.entrySet()) {
+            User user = entry.getKey();
+            List<Participation> userParticipations = entry.getValue();
+
+            int totalExpected = 0;
+            int totalSuccess = 0;
+
+            for (Participation p : userParticipations) {
+                Challenge challenge = p.getChallenge();
+                int expected = getExpectedCount(challenge, p);
+
+                long success = p.getAuthList().stream()
+                        .filter(Auth::getAuthSuccess)
+                        .count();
+
+                totalExpected += expected;
+                totalSuccess += Math.min((int) success, expected);
+            }
+
+            double rate = (totalExpected > 0)
+                    ? Math.round((totalSuccess * 1000.0 / totalExpected)) / 10.0
+                    : 0.0;
+
+            result.add(new RankingResponseDTO(
+                    user.getUserId(),
+                    user.getNickname(),
+                    rate,
+                    userParticipations.size()
+            ));
+        }
+
+        return result.stream()
+                .sorted(Comparator
+                        .comparingDouble(RankingResponseDTO::getSuccessRate).reversed()
+                        .thenComparingInt(RankingResponseDTO::getChallengeCount).reversed()
+                )
+                .collect(Collectors.toList());
+
+    }
+
+    public List<RankingResponseDTO> getFollowingRanking(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(()->new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        List<User> following = followRepository.findFolloweesByFollower(user);
+        List<RankingResponseDTO> all = getAllRanking();
+
+        return all.stream()
+                .filter(dto -> following.stream().anyMatch(f -> f.getUserId().equals(dto.getUserId())))
+                .toList();
+    }
+
+    private int getExpectedCount(Challenge challenge, Participation participation) {
+        LocalDate from = participation.getCreatedAt().toLocalDate();
+        LocalDate to = challenge.getEndDate().isBefore(LocalDate.now()) ? challenge.getEndDate() : LocalDate.now();
+
+        long days = from.datesUntil(to.plusDays(1)).count();
+        double ratio = getWeeklyRatio(challenge.getAuthFrequency());
+
+        return (int) Math.round(days * ratio);
+    }
+
+    private double getWeeklyRatio(String freq) {
+        return switch (freq.trim()) {
+            case "매일" -> 1.0;
+            case "평일 매일" -> 5.0 / 7.0;
+            case "주말 매일" -> 2.0 / 7.0;
+            case "주 1일" -> 1.0 / 7.0;
+            case "주 2일" -> 2.0 / 7.0;
+            case "주 3일" -> 3.0 / 7.0;
+            case "주 4일" -> 4.0 / 7.0;
+            case "주 5일" -> 5.0 / 7.0;
+            case "주 6일" -> 6.0 / 7.0;
+            default -> 0.0;
+        };
+    }
+}

--- a/src/main/java/capstone/TryAngle/service/RankingServiceImpl.java
+++ b/src/main/java/capstone/TryAngle/service/RankingServiceImpl.java
@@ -26,6 +26,7 @@ public class RankingServiceImpl implements RankingService {
     private final FollowRepository followRepository;
 
     public List<RankingResponseDTO> getAllRanking() {
+        List<User> allUsers = userRepository.findAll();
         List<Participation> participations = participationRepository.findAllWithChallengeAndAuth();
 
         Map<User, List<Participation>> userMap = participations.stream()
@@ -33,9 +34,8 @@ public class RankingServiceImpl implements RankingService {
 
         List<RankingResponseDTO> result = new ArrayList<>();
 
-        for (Map.Entry<User, List<Participation>> entry : userMap.entrySet()) {
-            User user = entry.getKey();
-            List<Participation> userParticipations = entry.getValue();
+        for (User user : allUsers) {
+            List<Participation> userParticipations = userMap.getOrDefault(user, Collections.emptyList());
 
             int totalExpected = 0;
             int totalSuccess = 0;
@@ -66,7 +66,7 @@ public class RankingServiceImpl implements RankingService {
 
         return result.stream()
                 .sorted(Comparator
-                        .comparingDouble(RankingResponseDTO::getSuccessRate).reversed()
+                        .comparingDouble(RankingResponseDTO::getSuccessRate)
                         .thenComparingInt(RankingResponseDTO::getChallengeCount).reversed()
                 )
                 .collect(Collectors.toList());

--- a/src/main/java/capstone/TryAngle/web/controller/RankingController.java
+++ b/src/main/java/capstone/TryAngle/web/controller/RankingController.java
@@ -1,0 +1,28 @@
+package capstone.TryAngle.web.controller;
+
+import capstone.TryAngle.common.ApiResponse;
+import capstone.TryAngle.common.status.SuccessStatus;
+import capstone.TryAngle.service.RankingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class RankingController {
+
+    private final RankingService rankingService;
+
+    @GetMapping("/ranking")
+    public ApiResponse<?> getAllRanking() {
+        return ApiResponse.onSuccess(SuccessStatus._OK, rankingService.getAllRanking());
+    }
+
+    @GetMapping("/ranking/following")
+    public ApiResponse<?> getFollowingRanking(@AuthenticationPrincipal User user) {
+        String email = user.getUsername();
+        return ApiResponse.onSuccess(SuccessStatus._OK, rankingService.getFollowingRanking(email));
+    }
+}

--- a/src/main/java/capstone/TryAngle/web/dto/RankingResponseDTO.java
+++ b/src/main/java/capstone/TryAngle/web/dto/RankingResponseDTO.java
@@ -1,0 +1,13 @@
+package capstone.TryAngle.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RankingResponseDTO {
+    private Integer userId;
+    private String nickname;
+    private double successRate;
+    private Integer challengeCount;
+}


### PR DESCRIPTION
- 전체 랭킹 조회
- 팔로우 랭킹 조회
기능 구현했습니다.

달성률 계산 로직은
1) startDate와 endDate 사이의 일수를 계산하고 (endDate보다 오늘 날짜가 먼저라면 startDate부터 오늘까지의 일수)
2) challenge의 authFrequency 값에 따라
"매일" -> 7/7
"평일 매일" -> 5/7
"주말 매일" -> 2/7
"주 1~6일" -> 1~6/7
을 곱해서 '모두 인증 성공한 경우를 가정한 일수'를 구하고,
3) 현재까지 해당 participation의 auth 중 auth_success가 true인 것들을 골라 '실제 인증 성공한 일수'를 구해서
4) (실제 인증 성공한 일수 / 모두 인증 성공한 경우를 가정한 일수) 비율에 따라 달성률 계산했습니다.