### PR TITLE
Ta 31 인증 구현

### DIFF
--- a/src/main/java/capstone/TryAngle/common/status/ErrorStatus.java
+++ b/src/main/java/capstone/TryAngle/common/status/ErrorStatus.java
@@ -18,6 +18,7 @@ ErrorStatus implements BaseErrorCode {
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON4001", "인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON4003", "금지된 요청입니다."),
     MISSING_REQUIRED_VALUE(HttpStatus.BAD_REQUEST, "COMMON4000", "입력되지 않은 필수값이 있습니다."),
+    IMAGE_NOT_FOUND(HttpStatus.CONFLICT, "COMMON404" , "이미지가 필수입니다."),
 
     // 사용자 관련 응답
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER4004", "사용자를 찾을 수 없습니다."),

--- a/src/main/java/capstone/TryAngle/common/status/ErrorStatus.java
+++ b/src/main/java/capstone/TryAngle/common/status/ErrorStatus.java
@@ -49,12 +49,15 @@ ErrorStatus implements BaseErrorCode {
     INVALID_INVITE_CODE(HttpStatus.CONFLICT, "PARTICIPATION409" , "잘못된 초대 코드 입니다." ),
     NOT_PARTICIPATING(HttpStatus.CONFLICT, "PARTICIPATION409" , "해당 챌린지에 참여하지 않은 유저입니다"),
     CHALLENGE_ALREADY_STARTED(HttpStatus.CONFLICT, "PARTICIPATION409" , "챌린지 시작 이후에는 참여 취소가 불가합니다."),
+    JOIN_TOO_LATE(HttpStatus.CONFLICT, "PARTICIPATION409" , "챌린지 시작 이후에는 참여 신청이 불가합니다."),
     LEADER_CANNOT_CANCEL_PARTICIPATION(HttpStatus.CONFLICT, "PARTICIPATION409" , "챌린지 리더는 참여 취소할 수 없습니다."),
 
     // 인증 관련 응답
     AUTH_NOT_FOUND(HttpStatus.CONFLICT, "AUTH404" , "해당 인증 내역을 찾을 수 없습니다."),
     ALREADY_VOTED(HttpStatus.CONFLICT, "AUTH409" , "이미 투표한 내역이 존재합니다."),
-    VOTE_NOT_FOUND(HttpStatus.CONFLICT, "AUTH404" , "아직 투표 내역이 존재하지 않습니다.");
+    VOTE_NOT_FOUND(HttpStatus.CONFLICT, "AUTH404" , "아직 투표 내역이 존재하지 않습니다."),
+    ALREADY_AUTH(HttpStatus.CONFLICT, "AUTH409" , "이미 인증한 내역이 존재합니다."),
+    NOT_AUTH_TIME(HttpStatus.CONFLICT, "AUTH409" , "인증 가능한 시간이 아닙니다.");
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;

--- a/src/main/java/capstone/TryAngle/model/challenge/Participation.java
+++ b/src/main/java/capstone/TryAngle/model/challenge/Participation.java
@@ -76,5 +76,12 @@ public class Participation {
             this.depositReturnDate = LocalDate.now();
         }
 
+    }
+    public void setSuccess(){
+        this.participationSuccess=true;
+    }
 
-    }}
+    public void setStatus(int i) {
+        this.status = i;
+    }
+}

--- a/src/main/java/capstone/TryAngle/model/challenge/Vote.java
+++ b/src/main/java/capstone/TryAngle/model/challenge/Vote.java
@@ -35,8 +35,8 @@ public class Vote {
     @Column(name = "reaction", nullable = true)
     private Reaction reaction;
 
-    @Column(name="vote_type", nullable = false)
-    private Boolean voteType;   // approve, deny
+    @Column(name="vote_type", nullable = true)
+    private Boolean voteType;  // approve, deny
 
     @CreatedDate
     @Column(name="created_at", nullable = false)
@@ -54,6 +54,10 @@ public class Vote {
 
     public void setReaction(Reaction reaction) {
         this.reaction = reaction;
+    }
+
+    public void setVoteType(Boolean voteType) {
+        this.voteType = voteType;
     }
 
 }

--- a/src/main/java/capstone/TryAngle/repository/ChallengeRepository.java
+++ b/src/main/java/capstone/TryAngle/repository/ChallengeRepository.java
@@ -9,4 +9,8 @@ import java.util.List;
 public interface ChallengeRepository extends JpaRepository<Challenge, Integer> {
 
     List<Challenge> findAllByEndDate(LocalDate now);
+
+    List<Challenge> findAllByStartDate(LocalDate today);
+
+    List<Challenge> findAllByEndDateBefore(LocalDate today);
 }

--- a/src/main/java/capstone/TryAngle/service/AuthService.java
+++ b/src/main/java/capstone/TryAngle/service/AuthService.java
@@ -13,7 +13,7 @@ public interface AuthService {
     void signup(UserRequestDTO.SignupRequestDTO request);
     UserResponseDTO.LoginResponseDTO login(String email, String rawPassword);
 
-    void createAuth(String email, AuthRequestDTO.createAuthDTO createAuthDTO);
+    AuthResponseDTO.createAuthDTO createAuth(String email, AuthRequestDTO.createAuthDTO createAuthDTO);
 
     void editAuth(Integer authenticationId, String email, AuthRequestDTO.editAuthDTO editAuthDTO);
 
@@ -26,4 +26,7 @@ public interface AuthService {
     void reactionAuth(String email, Integer authenticationId, AuthRequestDTO.reactionAuthDTO reactionAuthDTO);
 
     List<AuthResponseDTO.getAuthDTO> getAllAuth(String email, Integer challengeId);
+
+    AuthResponseDTO.getAuthDTO getMyAuth(String email, Integer challengeId);
 }
+

--- a/src/main/java/capstone/TryAngle/service/AuthServiceImpl.java
+++ b/src/main/java/capstone/TryAngle/service/AuthServiceImpl.java
@@ -19,7 +19,11 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -88,27 +92,49 @@ public class AuthServiceImpl implements AuthService {
     }
 
     @Override
-    public void createAuth(String email, AuthRequestDTO.createAuthDTO createAuthDTO) {
-
+    public AuthResponseDTO.createAuthDTO createAuth(String email, AuthRequestDTO.createAuthDTO createAuthDTO) {
 
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
+        Participation participation = participationRepository
+                .findByUserUserIdAndChallengeChallengeId(user.getUserId(), createAuthDTO.getChallengeId());
 
-        Participation participation = participationRepository.findByUserUserIdAndChallengeChallengeId(user.getUserId(), createAuthDTO.getChallengeId());
         if (participation == null) {
             throw new GeneralException(ErrorStatus.NOT_PARTICIPATING);
         }
+
+        Challenge challenge = participation.getChallenge();
+
+        LocalTime nowTime = LocalTime.now();
+        if (nowTime.isBefore(challenge.getAuthTimeStart()) || nowTime.isAfter(challenge.getAuthTimeEnd())) {
+            throw new GeneralException(ErrorStatus.NOT_AUTH_TIME);
+        }
+
+        LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
+        LocalDateTime endOfDay = startOfDay.plusDays(1);
+
+        boolean alreadyAuthenticated = authRepository.existsByParticipationParticipationIdAndCreatedAtBetween(
+                participation.getParticipationId(), startOfDay, endOfDay
+        );
+
+        if (alreadyAuthenticated) {
+            throw new GeneralException(ErrorStatus.ALREADY_AUTH);
+        }
+
         Auth auth = new Auth(
                 participation,
                 createAuthDTO.getAuthImage(),
                 createAuthDTO.getComment()
         );
 
-
-
         authRepository.save(auth);
+
+        return AuthResponseDTO.createAuthDTO.builder()
+                .authId(auth.getAuthenticationId())
+                .build();
     }
+
 
     @Override
     public void editAuth(Integer authenticationId, String email, AuthRequestDTO.editAuthDTO editAuthDTO) {
@@ -167,6 +193,45 @@ public class AuthServiceImpl implements AuthService {
                 .build();
     }
 
+    @Override
+    public AuthResponseDTO.getAuthDTO getMyAuth(String email, Integer challengeId) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        Participation participation = participationRepository
+                .findByUserUserIdAndChallengeChallengeId(user.getUserId(), challengeId);
+
+        if (participation == null) {
+            throw new GeneralException(ErrorStatus.NOT_PARTICIPATING);
+        }
+
+        // 오늘 날짜 기준 인증 검색
+        LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
+        LocalDateTime endOfDay = startOfDay.plusDays(1);
+
+        List<Auth> auths = authRepository.findByParticipationParticipationIdAndCreatedAtBetween(
+                participation.getParticipationId(), startOfDay, endOfDay
+        );
+
+        if (auths.isEmpty()) {
+            throw new GeneralException(ErrorStatus.AUTH_NOT_FOUND);
+        }
+
+        Auth latestAuth = auths.get(0);
+
+        int voteCount = voteRepository.countByAuth_AuthenticationId(latestAuth.getAuthenticationId());
+
+        return AuthResponseDTO.getAuthDTO.builder()
+                .authId(latestAuth.getAuthenticationId())
+                .challengeId(challengeId)
+                .userNickname(user.getNickname())
+                .comment(latestAuth.getComment())
+                .authImage(latestAuth.getAuthImage())
+                .voteCount(voteCount)
+                .authSuccess(latestAuth.getAuthSuccess())
+                .createdAt(latestAuth.getCreatedAt())
+                .build();
+    }
 
 
     @Override
@@ -201,14 +266,16 @@ public class AuthServiceImpl implements AuthService {
             throw new GeneralException(ErrorStatus.NOT_PARTICIPATING);
         }
 
-        // 이미 투표했는지 확인
-        boolean alreadyVoted = voteRepository.existsByUserUserIdAndAuthAuthenticationId(user.getUserId(), authenticationId);
-        if (alreadyVoted) {
-            throw new GeneralException(ErrorStatus.ALREADY_VOTED);
-        }
+        // vote가 있는지 확인
+        Optional<Vote> optionalVote = voteRepository.findByUserAndAuth(user, auth);
 
-        // 투표 생성
-        Vote vote = new Vote(user, auth, voteAuthDTO.getVoteType());
+        Vote vote;
+        if (optionalVote.isPresent()) {
+            vote = optionalVote.get();
+            vote.setVoteType(voteAuthDTO.getVoteType());
+        } else {
+            vote = new Vote(user, auth, voteAuthDTO.getVoteType());
+        }
 
         voteRepository.save(vote);
         voteService.evaluateAuthSuccessAfterVoting(auth);
@@ -222,11 +289,23 @@ public class AuthServiceImpl implements AuthService {
 
         Auth auth = authRepository.findById(authenticationId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.AUTH_NOT_FOUND));
-        Vote vote = voteRepository.findByUserAndAuth(user, auth)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.VOTE_NOT_FOUND));
+
         Reaction reaction = Reaction.values()[reactionAuthDTO.getReactionId()];
-        vote.setReaction(reaction);
+
+        // vote가 있는지 확인
+        Optional<Vote> optionalVote = voteRepository.findByUserAndAuth(user, auth);
+
+        Vote vote;
+        if (optionalVote.isPresent()) {
+            vote = optionalVote.get();
+            vote.setReaction(reaction);
+        } else {
+            vote = new Vote(user, auth, null);
+            vote.setReaction(reaction);
+            voteRepository.save(vote);
+        }
     }
+
 
     @Override
     public List<AuthResponseDTO.getAuthDTO> getAllAuth(String email, Integer challengeId) {
@@ -254,5 +333,7 @@ public class AuthServiceImpl implements AuthService {
                         .build())
                 .collect(Collectors.toList());
     }
+
+
 
 }

--- a/src/main/java/capstone/TryAngle/service/ChallengeService.java
+++ b/src/main/java/capstone/TryAngle/service/ChallengeService.java
@@ -30,4 +30,6 @@ public interface ChallengeService {
     void quitChallenge(Integer challengeId, String email);
 
     List<ChallengeResponseDTO.ChallengeDepositStatusDTO> getMyDepositStatus(String email);
+
+    ChallengeResponseDTO.ChallengeSuccessRateDTO getMySuccessRate(String email);
 }

--- a/src/main/java/capstone/TryAngle/service/ChallengeServiceImpl.java
+++ b/src/main/java/capstone/TryAngle/service/ChallengeServiceImpl.java
@@ -19,10 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -257,6 +254,10 @@ public class ChallengeServiceImpl implements ChallengeService {
         Challenge challenge = challengeRepository.findById(challengeId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.CHALLENGE_NOT_FOUND));
 
+        if (!challenge.getStartDate().isAfter(LocalDate.now())) {
+            throw new GeneralException(ErrorStatus.JOIN_TOO_LATE);
+        }
+
         // 비공개 챌린지라면 초대 코드
         if (!challenge.getChallengePublic()) {
             if (inviteCode == null || !inviteCode.equals(challenge.getInviteCode())) {
@@ -276,6 +277,7 @@ public class ChallengeServiceImpl implements ChallengeService {
         if (challenge.getNowPeople() != null && challenge.getNowPeople() >= challenge.getMaxPeople()) {
             throw new GeneralException(ErrorStatus.CHALLENGE_FULL);
         }
+
 
         // 최소 예치금 조건
         if (deposit < challenge.getMinDeposit()) {
@@ -308,9 +310,40 @@ public class ChallengeServiceImpl implements ChallengeService {
         user.updateChallengeMoney(currentChallengeMoney+deposit);
     }
 
+    @Scheduled(cron = "0 0 0 * * *") // 매일 자정
+    public void autoUpdateChallengeStatus() {
+        System.out.println("챌린지 상태 스케줄러");
+
+        LocalDate today = LocalDate.now();
+
+        // 오늘 시작하는 챌린지들
+        List<Challenge> startingChallenges = challengeRepository.findAllByStartDate(today);
+
+        for (Challenge challenge : startingChallenges) {
+            List<Participation> participants = participationRepository.findAllByChallengeChallengeId(challenge.getChallengeId());
+            for (Participation p : participants) {
+                if (p.getStatus() == 0) { // ready → progress
+                    p.setStatus(1);
+                }
+            }
+        }
+
+        // 오늘 기준으로 종료된 챌린지들의 참여자 상태도 완료로 갱신
+        List<Challenge> endingChallenges = challengeRepository.findAllByEndDateBefore(today);
+        for (Challenge challenge : endingChallenges) {
+            List<Participation> participants = participationRepository.findAllByChallengeChallengeId(challenge.getChallengeId());
+            for (Participation p : participants) {
+                if (p.getStatus() != 2) {
+                    p.setStatus(2);
+                }
+            }
+        }
+    }
+
 
     @Scheduled(cron = "0 0 0 * * *") // 매일 자정
     public void autoEndChallenges() {
+        System.out.println("스케쥴링");
         List<Challenge> endingChallenges = challengeRepository
                 .findAllByEndDate(LocalDate.now());
 
@@ -321,35 +354,74 @@ public class ChallengeServiceImpl implements ChallengeService {
 
     @Override
     public void endChallenge(Integer challengeId) {
-
         Challenge challenge = challengeRepository.findById(challengeId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.CHALLENGE_NOT_FOUND));
+
         Boolean isDonation = challenge.getReturnType();  // true: 기부, false: 환급
+        List<Participation> participations = participationRepository.findAllByChallengeChallengeId(challengeId);
 
-        List<Participation> participations = participationRepository
-                .findAllByChallengeChallengeId(challengeId);
+        int alphaPool = 0;
+        List<Participation> fullySuccessParticipants = new ArrayList<>();
 
+        // 1. 참여자별 달성률 및 기본 환급 처리
         for (Participation participation : participations) {
-            // 상태 종료로 변경
-            participation.markAsCompleted();
+            int expected = getExpectedCount(challenge, participation);
+            long success = participation.getAuthList().stream()
+                    .filter(Auth::getAuthSuccess)
+                    .count();
 
-            // 성공한 경우만 처리
-            if (Boolean.TRUE.equals(participation.getParticipationSuccess())) {
-                int depositAmount = participation.getDepositAmount();
-                User participant = participation.getUser();
+            double rate = expected > 0 ? (double) success / expected : 0.0;
+            System.out.println("성공률"+ expected + "suc" + success + "rate: "+ rate);
+            int deposit = participation.getDepositAmount();
+            int refundAmount = 0;
 
-                // 입금 상태 처리 (donated / refunded)
-                participation.returnDeposit(isDonation);
+            if (rate >= 0.9) {
+                participation.setSuccess();
+                refundAmount = deposit;
 
-                if (!isDonation) {
-                    // 환급인 경우만 돈 처리
-                    participant.updateChallengeMoney(participant.getChallengeMoney() - depositAmount);
-                    participant.updateReturnMoney(depositAmount); // returnMoney += depositAmount
-
+                // 100% 성공한 사람 저장 (추후 α 분배 대상)
+                if (rate == 1.0) {
+                    fullySuccessParticipants.add(participation);
                 }
+
+            } else if (rate >= 0.5) {
+                participation.setSuccess();
+                refundAmount = (int) Math.round(deposit * rate);
+            } else {
+                refundAmount = 0;
+            }
+
+            // 2. 종료 처리
+            participation.markAsCompleted();
+            participation.returnDeposit(isDonation);
+
+            // 3. 금액 처리 (기부 아닐 때만)
+            if (!isDonation) {
+                User user = participation.getUser();
+                user.updateChallengeMoney(user.getChallengeMoney() - deposit);
+
+                // 환급
+                if (refundAmount > 0) {
+                    user.updateReturnMoney(user.getReturnMoney() + refundAmount);
+                }
+
+                // α 풀 계산
+                alphaPool += (deposit - refundAmount);
+            }
+        }
+
+        // 4. α 정산 (기부 아님 + 100% 성공자 있음)
+        if (!isDonation && alphaPool > 0 && !fullySuccessParticipants.isEmpty()) {
+            int share = alphaPool / fullySuccessParticipants.size();
+            for (Participation p : fullySuccessParticipants) {
+                User user = p.getUser();
+                user.updateReturnMoney(user.getReturnMoney() + share);
             }
         }
     }
+
+
+
 
     @Override
     public ChallengeResponseDTO.createInviteCodeDTO createInviteCode(String inviteCode, Integer challengeId, String email) {
@@ -417,7 +489,7 @@ public class ChallengeServiceImpl implements ChallengeService {
         return participations.stream()
                 .map(p -> {
                     Integer depositAmount = p.getDepositAmount() != null ? p.getDepositAmount() : 0;
-                    Integer status = p.getStatus();
+                    Integer status = p.getDepositStatus();
 
                     int refundAmount = (status != null && status == 0) ? depositAmount : 0;
 
@@ -435,6 +507,59 @@ public class ChallengeServiceImpl implements ChallengeService {
                 .collect(Collectors.toList());
     }
 
+    @Override
+    public ChallengeResponseDTO.ChallengeSuccessRateDTO getMySuccessRate(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        List<Participation> userParticipations = participationRepository.findAllByUserUserId(user.getUserId());
+
+        int totalExpected = 0;
+        int totalSuccess = 0;
+        Map<Category, Integer> expectedPerCategory = new HashMap<>();
+        Map<Category, Integer> successPerCategory = new HashMap<>();
+        for (Participation p : userParticipations) {
+            Challenge challenge = p.getChallenge();
+            int expected = getExpectedCount(challenge, p);
+            long success = p.getAuthList().stream()
+                    .filter(Auth::getAuthSuccess)
+                    .count();
+
+            totalExpected += expected;
+            totalSuccess += Math.min((int) success, expected);
+
+            expectedPerCategory.merge(challenge.getCategory(), expected, Integer::sum);
+            successPerCategory.merge(challenge.getCategory(), Math.min((int) success, expected), Integer::sum);
+        }
+
+        double totalSuccessRate = (totalExpected > 0)
+                ? Math.round((totalSuccess * 1000.0 / totalExpected)) / 10.0
+                : 0.0;
+
+
+        List<ChallengeResponseDTO.ChallengeSuccessRateDTO.CategorySuccessRateDTO> categoryRates = new ArrayList<>();
+        for (Category category : expectedPerCategory.keySet()) {
+            int expected = expectedPerCategory.get(category);
+            int success = successPerCategory.getOrDefault(category, 0);
+
+            double rate = (expected > 0)
+                    ? Math.round((success * 1000.0 / expected)) / 10.0
+                    : 0.0;
+
+            categoryRates.add(ChallengeResponseDTO.ChallengeSuccessRateDTO.CategorySuccessRateDTO.builder()
+                    .category(category.name())  // 필요시 한글로 매핑 가능
+                    .successRate(rate)
+                    .build());
+        }
+
+        return ChallengeResponseDTO.ChallengeSuccessRateDTO.builder()
+                .totalSuccessRate(totalSuccessRate)
+                .categorySuccessRate(categoryRates)
+                .build();
+    }
+
+
+
     private String convertStatusToString    (Integer statusCode) {
         return switch (statusCode) {
             case 0 -> "refunded";
@@ -444,6 +569,31 @@ public class ChallengeServiceImpl implements ChallengeService {
         };
     }
 
+    private int getExpectedCount(Challenge challenge, Participation participation) {
+        LocalDate from = challenge.getStartDate();
+        LocalDate to = challenge.getEndDate().isBefore(LocalDate.now()) ? challenge.getEndDate() : LocalDate.now();
+
+        long days = from.datesUntil(to.plusDays(1)).count();
+        double ratio = getWeeklyRatio(challenge.getAuthFrequency());
+
+        System.out.println("From "+from+"to "+to+ "days "+ days+ "ratio "+ratio);
+        return (int) Math.round(days * ratio);
+    }
+
+    private double getWeeklyRatio(String freq) {
+        return switch (freq.trim()) {
+            case "매일" -> 1.0;
+            case "평일 매일" -> 5.0 / 7.0;
+            case "주말 매일" -> 2.0 / 7.0;
+            case "주 1일" -> 1.0 / 7.0;
+            case "주 2일" -> 2.0 / 7.0;
+            case "주 3일" -> 3.0 / 7.0;
+            case "주 4일" -> 4.0 / 7.0;
+            case "주 5일" -> 5.0 / 7.0;
+            case "주 6일" -> 6.0 / 7.0;
+            default -> 0.0;
+        };
+    }
 
 }
 

--- a/src/main/java/capstone/TryAngle/service/RankingServiceImpl.java
+++ b/src/main/java/capstone/TryAngle/service/RankingServiceImpl.java
@@ -86,7 +86,7 @@ public class RankingServiceImpl implements RankingService {
     }
 
     private int getExpectedCount(Challenge challenge, Participation participation) {
-        LocalDate from = participation.getCreatedAt().toLocalDate();
+        LocalDate from = challenge.getStartDate();
         LocalDate to = challenge.getEndDate().isBefore(LocalDate.now()) ? challenge.getEndDate() : LocalDate.now();
 
         long days = from.datesUntil(to.plusDays(1)).count();

--- a/src/main/java/capstone/TryAngle/service/VoteServiceImpl.java
+++ b/src/main/java/capstone/TryAngle/service/VoteServiceImpl.java
@@ -56,16 +56,18 @@ public class VoteServiceImpl implements VoteService {
                 challengeId, todayStart, todayEnd
         );
 
-        List<Participation> participants = participationRepository.findAllByChallengeChallengeId(challengeId);
+        List<Participation> participations = participationRepository.findAllByChallengeChallengeId(challengeId);
 
         List<ChallengeResponseDTO.VoteStatusDTO> result = new ArrayList<>();
 
-        for (Participation p : participants) {
+        for (Participation p : participations) {
             if (p.getUser().getUserId().equals(user.getUserId())) continue;
             boolean voted = false;
+            String authImage = null;
 
             for (Auth auth : todayAuths) {
                 if (auth.getParticipation().getUser().getUserId().equals(p.getUser().getUserId())) {
+                    authImage = auth.getAuthImage();
                     // 내 투표가 존재하는지 확인
                     boolean hasVoted = voteRepository.existsByAuthAuthenticationIdAndUserUserId(
                             auth.getAuthenticationId(), user.getUserId()
@@ -79,7 +81,10 @@ public class VoteServiceImpl implements VoteService {
 
             result.add(ChallengeResponseDTO.VoteStatusDTO.builder()
                     .nickname(p.getUser().getNickname())
+                    .voter_id(p.getUser().getUserId())
+                    .profileImage(p.getUser().getProfileImage())
                     .voted(voted)
+                    .auth_image(authImage)
                     .build());
         }
 

--- a/src/main/java/capstone/TryAngle/web/controller/AuthController.java
+++ b/src/main/java/capstone/TryAngle/web/controller/AuthController.java
@@ -65,8 +65,8 @@ public class AuthController {
         }
 
 
-        authService.createAuth(email, createAuthDTO);
-        return ApiResponse.onSuccess(SuccessStatus.AUTH_CREATE_SUCCESS, null);
+
+        return ApiResponse.onSuccess(SuccessStatus.AUTH_CREATE_SUCCESS,   authService.createAuth(email, createAuthDTO));
     }
 
     // 인증 수정
@@ -107,6 +107,12 @@ public class AuthController {
         return ApiResponse.onSuccess(SuccessStatus._OK, authService.getAuthById(email, authenticationId));
     }
 
+    @GetMapping("/my/{challengeId}")
+    public ApiResponse<?> getMyAuth(@PathVariable("challengeId") Integer challengeId, @AuthenticationPrincipal User user){
+        String email =user.getUsername();
+        return ApiResponse.onSuccess(SuccessStatus._OK, authService.getMyAuth(email, challengeId));
+    }
+
     // 인증 전체 조회
     @GetMapping("/all/{challengeId}")
     public ApiResponse<?> getAllAuth(@PathVariable Integer challengeId, @AuthenticationPrincipal User user){
@@ -137,4 +143,7 @@ public class AuthController {
         authService.reactionAuth(email, authenticationId, reactionAuthDTO);
         return ApiResponse.onSuccess(SuccessStatus._OK, null);
     }
+
+
+
 }

--- a/src/main/java/capstone/TryAngle/web/controller/AuthController.java
+++ b/src/main/java/capstone/TryAngle/web/controller/AuthController.java
@@ -1,6 +1,8 @@
 package capstone.TryAngle.web.controller;
 
 import capstone.TryAngle.common.ApiResponse;
+import capstone.TryAngle.common.GeneralException;
+import capstone.TryAngle.common.status.ErrorStatus;
 import capstone.TryAngle.common.status.SuccessStatus;
 import capstone.TryAngle.service.AuthService;
 import capstone.TryAngle.service.ChallengeService;
@@ -58,7 +60,8 @@ public class AuthController {
                 throw new RuntimeException("이미지 업로드 실패", e);
             }
         } else {
-            throw new IllegalArgumentException("이미지 파일은 필수입니다.");
+//            throw new IllegalArgumentException("이미지 파일은 필수입니다.");
+            throw new GeneralException(ErrorStatus.IMAGE_NOT_FOUND);
         }
 
 

--- a/src/main/java/capstone/TryAngle/web/controller/ChallengeController.java
+++ b/src/main/java/capstone/TryAngle/web/controller/ChallengeController.java
@@ -179,5 +179,12 @@ public class ChallengeController {
         return ApiResponse.onSuccess(SuccessStatus._OK,voteService.getMyVoteStatus(challengeId, email));
     }
 
+    // 나의 챌린지 달성률 조회 (전체, 개별)
+    @GetMapping("/rate/total")
+    public ApiResponse<?> getMySuccessRate(
+            @AuthenticationPrincipal User loginUser) {
+        String email = loginUser.getUsername();
+        return ApiResponse.onSuccess(SuccessStatus._OK,challengeService.getMySuccessRate(email));
+    }
 
 }

--- a/src/main/java/capstone/TryAngle/web/dto/AuthResponseDTO.java
+++ b/src/main/java/capstone/TryAngle/web/dto/AuthResponseDTO.java
@@ -34,4 +34,14 @@ public class AuthResponseDTO {
 
     }
 
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class createAuthDTO {
+        @JsonProperty("auth_id")
+       private Integer authId;
+
+    }
+
 }

--- a/src/main/java/capstone/TryAngle/web/dto/ChallengeResponseDTO.java
+++ b/src/main/java/capstone/TryAngle/web/dto/ChallengeResponseDTO.java
@@ -171,6 +171,9 @@ public class ChallengeResponseDTO {
     @Builder
     public static class VoteStatusDTO {
         private String nickname;
+        private Integer voter_id;
+        private String profileImage;
         private boolean voted;
+        private String auth_image;
     }
 }

--- a/src/main/java/capstone/TryAngle/web/dto/ChallengeResponseDTO.java
+++ b/src/main/java/capstone/TryAngle/web/dto/ChallengeResponseDTO.java
@@ -176,4 +176,24 @@ public class ChallengeResponseDTO {
         private boolean voted;
         private String auth_image;
     }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ChallengeSuccessRateDTO {
+
+        private double totalSuccessRate;
+
+        private List<CategorySuccessRateDTO> categorySuccessRate;
+
+        @Getter
+        @Builder
+        @AllArgsConstructor
+        @NoArgsConstructor
+        public static class CategorySuccessRateDTO {
+            private String category;
+            private double successRate;
+        }
+    }
 }


### PR DESCRIPTION
- 추가 요청 api 
- [x] 특정 챌린지에 대한 내 인증 정보 조회 (/authentication/my/{challengeId}) 
	: 한 챌린지에 대해 유저가 오늘 인증한 내역 조회 (개별 조회 달라고 했는데 하나의 챌린지 id에 대해 여러 인증이 있어서 오늘 추가된 인증만 반환합니다. 그냥 전체 리스트가 필요한거면 말해주세여)


- 리턴값 수정
- [x] 챌린지 투표 현황 리스트 조회(/challenge/${challengeId}/users/vote) :  이미지, id 등 포함
- [x] 인증 추가 (/authentication) : auth_id 추가

- 로직 수정
- [x] 투표, 리액션 (authentication/{authID}/vote 혹은 reaction) : 투표 해야만 리액션 추가 가능 -> 둘중 아무거나 먼저 해도 작동하도록 수정
    -  ALTER TABLE vote MODIFY reaction ENUM('LIKE', 'DOUBT', 'SUPPORT', 'BEST') NULL;
    -  ALTER TABLE vote MODIFY vote_type BOOLEAN NULL;
- [x] 내 챌린지별 예치금 조회 (challenge/my/deposit) : 예치금 조회 status 초기값 not_refunded_yet 수정
- [x] 인증 추가는 인증 가능 시간 내에만 가능하도록. 넘기면 인증 업로드 못하게 막아둠
- [x] 달성률 로직에 startdate가 참여 생성일로 되어있길래 챌린지 시작일로 변경했습니다.
- [x]  스케줄링도 수정해서 서버 계속 켜놓고 있으면 자정마다 enddate 맞춰서 환급되고 이런거 .. 보여용.. 근데 영상에서 이걸 어케 보여줘야하지 ㅜㅜ.

- 구현 완료
- [x] 내 성공률 조회
